### PR TITLE
String handling fails if the string contains characters used in an object or array

### DIFF
--- a/specs/lockrSpecs.js
+++ b/specs/lockrSpecs.js
@@ -36,6 +36,14 @@ describe('Lockr::Retrieving data', function  () {
     expect(contents[2]).toEqual(123);
     expect(contents[0]).toEqual(123.123);
   });
+
+  it('should return strings containing "{"" as strings', function () {
+    Lockr.flush(); // Clear up before test
+    var theString = 'This is a string containing the characters "{", "}", "[", "]", ":" which are used in objects';
+
+    Lockr.set('aString', theString);
+    expect(Lockr.get('aString')).toEqual(theString);
+  });
 });
 describe('Lockr::Flushing data', function  () {
   it('should clear all contents of the localStorage', function () {


### PR DESCRIPTION
I've added a test to highlight a bug in string handling.

Retrieving a string containing the characters "{", "}", "[", "]", or ":" throws an exception as the code attempts to treat it as an object as fails to parse it as it is not valid JSON.
