### PR TITLE
2 fixes

### DIFF
--- a/lockr.js
+++ b/lockr.js
@@ -67,12 +67,18 @@
     try {
       value = JSON.parse(localStorage.getItem(query_key));
     } catch (e) {
-      value = null;
+      if( localStorage[query_key] ){
+        value = JSON.parse('{"data":"' + localStorage.getItem(query_key) + '"}')
+      }else{
+        value = null;
+      }
     }
     if(value === null)
       return missing;
     else
-      return (value.data || missing);
+        return (typeof value == 'object' && typeof value.data != 'undefined')
+                ? value.data
+                : (value || missing);
   };
 
   Lockr.sadd = function(key, value, options) {

--- a/specs/lockrSpecs.js
+++ b/specs/lockrSpecs.js
@@ -26,6 +26,9 @@ describe('Lockr.get', function () {
     Lockr.sadd('array', 2);
     Lockr.sadd('array', 3);
     Lockr.set('hash', {"test": 123, "hey": "whatsup"});
+    localStorage.nativemethod = 'NativeMethod'
+    Lockr.set('valueFalse', false)
+    Lockr.set('value0', 0)
   });
 
   it('returns the value for the given key from the localStorage', function () {
@@ -39,6 +42,24 @@ describe('Lockr.get', function () {
 
     expect(value).not.toBeNull();
     expect(value).toBeUndefined();
+  });
+
+  it('returns the value for the given key from the localStorage which set by native method', function () {
+    var value = Lockr.get('nativemethod');
+
+    expect(value).toEqual('NativeMethod');
+  });
+
+  it('returns the value for the given key from the localStorage which equals false', function () {
+    var value = Lockr.get('valueFalse');
+
+    expect(value).toEqual(false);
+  });
+
+  it('returns the value for the given key from the localStorage which equals 0', function () {
+    var value = Lockr.get('value0');
+
+    expect(value).toEqual(0);
   });
 
   it('gets all contents of the localStorage', function () {


### PR DESCRIPTION
**support for getting non-Lockr value**

if someone stored some value before using Lockr, that value can now be getting by using Lockr.get()

**can now get value that equals 0 or false**

if use Lockr.get(key, defaultValue) and the stored value is 0 or false, the result is defaultValue, not 0 or false. this will fix it.