### PR TITLE
Fix bug causing crash if localStorage not available

### DIFF
--- a/lockr.js
+++ b/lockr.js
@@ -67,11 +67,15 @@
     try {
       value = JSON.parse(localStorage.getItem(query_key));
     } catch (e) {
-      if( localStorage[query_key] ){
-        value = JSON.parse('{"data":"' + localStorage.getItem(query_key) + '"}')
-      }else{
-        value = null;
-      }
+        try {
+            if(localStorage[query_key]) {
+                value = JSON.parse('{"data":"' + localStorage.getItem(query_key) + '"}');
+            } else{
+                value = null;
+            }
+        } catch (e) {
+            if (console) console.warn("Lockr could not load the item with key " + key);
+        }
     }
     if(value === null) {
       return missing;


### PR DESCRIPTION
Greetings,

I'm doing some server-side rendering and was getting this error when trying to build my app:

```js
      if( localStorage[query_key] ){
          ^
ReferenceError: localStorage is not defined
    at Object.Lockr.get (/Users/victor/Development/LocationKit/data-mapping-tool/node_modules/lockr/lockr.js:70:11)
    at Object.module.exports.Object.defineProperty.value (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/src/reducers/UserReducer.js:8:21)
    at __webpack_require__ (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/webpack/bootstrap 308a988ba6b83a98b059:19:1)
    at Object.module.exports.Object.defineProperty.value (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/src/components/App/App.js:11:53)
    at __webpack_require__ (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/webpack/bootstrap 308a988ba6b83a98b059:19:1)
    at Object.<anonymous> (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/src/routes.js:9:39)
    at __webpack_require__ (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/webpack/bootstrap 308a988ba6b83a98b059:19:1)
    at Object.module.exports.Object.defineProperty.value (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/src/handlers/main.js:6:26)
    at __webpack_require__ (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/webpack/bootstrap 308a988ba6b83a98b059:19:1)
    at Object.<anonymous> (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/src/server.js:49:32)
    at __webpack_require__ (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/webpack/bootstrap 308a988ba6b83a98b059:19:1)
    at module.exports.obj.__esModule.default (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/webpack/bootstrap 308a988ba6b83a98b059:39:1)
    at Object.<anonymous> (/Users/victor/Development/LocationKit/data-mapping-tool/build/webpack:/webpack/bootstrap 308a988ba6b83a98b059:39:1)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Function.Module.runMain (module.js:457:10)
    at startup (node.js:138:18)
    at node.js:974:3
```
It only started recently as this version (0.8.3) didn't make it to npm until 16 days ago. Now my whole app crashes on build. Going back to 0.8.2 explicitly fixes the build as it takes me back in time before that commit was applied.

This PR should fix that issue and prevent crashes when running server-side.