### PR TITLE
Another fix for a crash condition

### DIFF
--- a/lockr.js
+++ b/lockr.js
@@ -79,7 +79,7 @@
     }
     if(value === null) {
       return missing;
-    } else if (typeof value.data !== 'undefined') {
+    } else if (typeof value === 'object' && typeof value.data !== 'undefined') {
       return value.data;
     } else {
       return missing;


### PR DESCRIPTION
This would crash in the case where `value` was `undefined`, because you'd get an error `TypeError: Cannot read property 'data' of undefined` if it was not defined. 

Now checking not only that it's defined, but that it's an object before trying to read the `.data` property from it (so if it's a number or string it won't try to check it's `.data` property either)