### PR TITLE
Take prefix into account in getAll-function

### DIFF
--- a/lockr.js
+++ b/lockr.js
@@ -130,9 +130,13 @@
 
   Lockr.getAll = function () {
     var keys = Object.keys(localStorage);
+    
+    keys = keys.filter(function (key) {
+      return key.indexOf(Lockr.prefix) !== -1
+    });
 
     return keys.map(function (key) {
-      return Lockr.get(key);
+      return Lockr.get(key.substr(Lockr.prefix.length));
     });
   };
 


### PR DESCRIPTION
When using lockr with a prefix, getAll() returns all localStorage-values, including those that do not have the specified prefix. This is a simple fix that works with or without a prefix.

Perhaps it should be considered to add a function that returns all keys/value-pairs or just all keys? Considering most other functions in the library depend on keys, the values by them selves aren't very useful.