### PR TITLE
Catching value of undefined from localStorage.getItem

### DIFF
--- a/lockr.js
+++ b/lockr.js
@@ -73,7 +73,7 @@
                 value = null;
             }
     }
-    if(value === null) {
+    if(!value || value === null) {
       return missing;
     } else if (typeof value === 'object' && typeof value.data !== 'undefined') {
       return value.data;


### PR DESCRIPTION
Ran into this when trying to test modules that use Lockr: when localStorage is not available, a JSON.parse of localStorage.getItem() returns undefined, not null. 
