### PR TITLE
Clarify Example for Lockr.prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Lockr.set('username', 'Coyote'); // Saved as string
 localStorage.getItem('username');
 > null
 localStorage.getItem('lockr_username');
-> {"data":123}
+> {"data":"Coyote"}
 ```
 *Please note that* when prefix is set, ```flush``` method deletes only keys that are prefixed, and ignores the rest.
 


### PR DESCRIPTION
The prefix example set the value to "Coyote" using Lockr.set("username", "Coyote") and returned "123" using Lockr.get("username") instead of "Coyote". This lead to confusion as pointed out in #55.